### PR TITLE
Update passport-oauth to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "main": "./lib/passport-dropbox-oauth2",
   "dependencies": {
-    "passport-oauth": "^0.1.15",
+    "passport-oauth": "^1.0.0",
     "pkginfo": "^0.2.3"
   },
   "engines": {


### PR DESCRIPTION
Passport 0.3.0 requires strategies to use passport-oauth 1.0.0.

https://github.com/jaredhanson/passport/issues/400
